### PR TITLE
Adding Vagrant/Docker Configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:latest
+ADD . /go/src/github.com/dustacio/redis-dns-server
+RUN go get github.com/miekg/dns
+RUN go get github.com/elcuervo/redisurl
+RUN go get github.com/hoisie/redis
+RUN go install github.com/dustacio/redis-dns-server
+ENTRYPOINT ["/go/bin/redis-dns-server", \
+            "-domain=${DOMAIN}", \
+            "-hostname=${HOSTNAME}", \
+            "-redis-server-url=${REDIS_SERVER}"]
+EXPOSE 53

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.synced_folder ".", "/vagrant"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "ubuntu-14.04-amd64"
+  config.vm.network "private_network", type: :dhcp, auto_config: true
+  config.vm.provision "shell" do |s|
+    s.inline = "cd /vagrant && bash scripts/vagrant.up.sh"
+  end
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+    v.cpus = 2
+    v.gui = false
+  end
+end

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,8 @@
+redis-dns-server:
+  build: .
+  links:
+   - redis
+  ports:
+   - "5353:53"
+redis:
+  image: redis:latest

--- a/scripts/vagrant.up.sh
+++ b/scripts/vagrant.up.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+apt-get update && apt-get upgrade -y
+apt-get install -y docker.io redis-server 
+service redis-server restart
+
+exit 0


### PR DESCRIPTION
Have Docker building with a minimal config.  The `ENTRYPOINT` needs work... to support Docker links, but this is just for testing to get it working first.  Copied a Redis entry from our `$dayjob` and `SET` it in my local Redis... but can't seem to get it working:

```
$ vagrant up

$ vagrant ssh

vagrant> $ sudo su -

vagrant> # cd /vagrant

vagrant> # docker build -t 'redis-dns-server:latest' .

vagrant> # docker run -it \
                  -e "DOMAIN=johnny.com." \
                  -e "REDIS_SERVER=redis://localhost:6379/0"  \
                  redis-dns-server:latest
```

I get different variations of `panic: runtime error: index out of range` no matter what I try:

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/elcuervo/redisurl.Parse(0xc20801e0a0, 0x17, 0x1a)
    /go/src/github.com/elcuervo/redisurl/redisurl.go:47 +0x539
main.RedisClient(0x7ffc436c7eec, 0xf, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/dustacio/redis-dns-server/main.go:66 +0x4f
main.main()
    /go/src/github.com/dustacio/redis-dns-server/main.go:53 +0x3d7

goroutine 2 [runnable]:
runtime.forcegchelper()
    /usr/src/go/src/runtime/proc.go:90
runtime.goexit()
    /usr/src/go/src/runtime/asm_amd64.s:2232 +0x1

goroutine 3 [runnable]:
runtime.bgsweep()
    /usr/src/go/src/runtime/mgc0.go:82
runtime.goexit()
    /usr/src/go/src/runtime/asm_amd64.s:2232 +0x1

goroutine 4 [runnable]:
runtime.runfinq()
    /usr/src/go/src/runtime/malloc.go:712
runtime.goexit()
    /usr/src/go/src/runtime/asm_amd64.s:2232 +0x1
```
